### PR TITLE
Fix requirements in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import os
 from setuptools import find_packages, setup
+
+def readfile(filename):
+    with open(filename, encoding="utf-8") as fp:
+        filecontents = fp.read()
+    return filecontents
 
 setup(
     name="nnest",
@@ -15,13 +21,7 @@ setup(
     license="MIT",
     packages=find_packages(),
     provides=["nnest"],
-    install_requires=["torch>=1.3.1",
-              "tensorboard>=1.14",
-              "numpy",
-              "scipy",
-              "matplotlib",
-              "pandas",
-              "scikitlearn",
-              "tqdm",
-              "pillow"],
+    install_requires=readfile(
+        os.path.join(os.path.dirname(__file__), "requirements.txt")
+    )
 )


### PR DESCRIPTION
The version of nnest on PyPI fails to install for me. This seems to be an issue with the dependency on `scikitlearn` in the `install_requirements` section of `setup.py`, where I think `scikitlearn` should instead be called `scikit-learn` as in the `requirements.txt` file.

Just to make sure things are always consistent with the `requirements.txt` file, this PR reads in the install requirements from the `requirements.txt` file rather than having to specify them again (with the risk of additional typos!). 